### PR TITLE
district_futa_maid_dispatch_center

### DIFF
--- a/src/registed/ngnl.ts
+++ b/src/registed/ngnl.ts
@@ -1,6 +1,6 @@
 import { useRing, useSimple } from "../planet-register";
 
 // ====ngnl 3479729949====
-useSimple('district_elf_lab', 'district_elf_nanoalloy', 'district_elf_patrol', 'district_elf_garden');
+useSimple('district_elf_lab', 'district_elf_nanoalloy', 'district_elf_patrol', 'district_elf_garden','district_futa_maid_dispatch_center');
 useRing('district_fe_fluegel_rw_city', 'district_fe_fluegel_rw_alloys', 'district_fe_fluegel_rw_goods', 'district_fe_fluegel_rw_research')
 useRing('district_exmachina_rw_city', 'district_exmachina_rw_alloys', 'district_exmachina_rw_goods')


### PR DESCRIPTION
精液星球改造会使得district_futa_maid_dispatch_center从普通区域变成主区域
此时应该与district_city 合并